### PR TITLE
Fix hash bang lines

### DIFF
--- a/parse_blast.pl
+++ b/parse_blast.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 # Converted from parse_blastx.pl to parse_blast.pl 
 # 
 # program written by Alejandro Schaffer to convert a blastx 

--- a/vadr.pm
+++ b/vadr.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # 
 # version: 1.1 [May 2020]
 #

--- a/vadr_seed.pm
+++ b/vadr_seed.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # 
 # version: 1.0.6 [April 2020]
 #


### PR DESCRIPTION
`/usr/bin/perl` was hardcoded in some files
replaced with `/usr/bin/env perl` to ensure correct perl in PATH is used.
