### PR TITLE
Created Docker image for VADR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:18.04
+
+MAINTAINER Tomer Altman, Altman Analytics LLC
+
+Workdir /root
+
+### Install apt dependencies
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y cpanminus \
+    build-essential \
+    libnet-ssleay-perl \
+    libcrypt-ssleay-perl \
+    git \
+    curl \
+    zip \
+    autoconf
+
+### Perl dependencies:
+
+RUN cpanm install Inline
+RUN cpanm install Inline::C
+RUN cpanm install LWP::Simple
+RUN cpanm install LWP::Protocol::https
+
+### Install VADR:
+RUN git clone https://github.com/nawrockie/vadr.git
+RUN cd vadr && ./vadr-install.sh linux
+
+### Set up VADR environment variables:
+ENV VADRINSTALLDIR="/root/vadr"
+ENV VADRSCRIPTSDIR="$VADRINSTALLDIR/vadr"
+ENV VADRMODELDIR="$VADRINSTALLDIR/vadr-models"
+ENV VADRINFERNALDIR="$VADRINSTALLDIR/infernal/binaries"
+ENV VADREASELDIR="$VADRINSTALLDIR/infernal/binaries"
+ENV VADRHMMERDIR="$VADRINSTALLDIR/hmmer/binaries"
+ENV VADRBIOEASELDIR="$VADRINSTALLDIR/Bio-Easel"
+ENV VADRSEQUIPDIR="$VADRINSTALLDIR/sequip"
+ENV VADRBLASTDIR="$VADRINSTALLDIR/ncbi-blast/bin"
+ENV PERL5LIB="$VADRSCRIPTSDIR:$VADRSEQUIPDIR:$VADRBIOEASELDIR/blib/lib:$VADRBIOEASELDIR/blib/arch:$PERL5LIB"
+ENV PATH="$VADRSCRIPTSDIR:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build-docker-image:
+	sudo docker image build -t vadr:1.1 .
+
+test-docker-image:
+	sudo docker run vadr:1.1 '/bin/bash' '-c' '$VADRSCRIPTSDIR/testfiles/do-install-tests-local.sh'
+


### PR DESCRIPTION
The Dockerfile contains all of the instructions necessary to build VADR from a fresh Ubuntu install.

See the Makefile for brief commands to build the Docker image, and test it as a container.

The current Docker image can be fetched using:

`docker pull taltman/vadr:1.1`

I hope this makes it easier for folks to start working with VADR!